### PR TITLE
Allow host directory to be mounted in VM and set LTP location, also enable OpenPOSIX

### DIFF
--- a/backend.pm
+++ b/backend.pm
@@ -207,6 +207,17 @@ sub run_cmds
 	return wantarray? @log : 0;
 }
 
+sub interactive
+{
+    my ($self) = @_;
+
+    if (defined($self->{'interactive'})) {
+        msg('Run: ' . $self->{'interactive'}->($self) . "\n");
+    } else {
+        msg("Interactive not implemented for $self->{'name'}\n");
+    }
+}
+
 sub start
 {
 	my ($self) = @_;
@@ -286,10 +297,17 @@ sub qemu_read_file
 	return @lines;
 }
 
+sub qemu_cmdline
+{
+    my ($self) = @_;
+
+    return "qemu-system-$self->{'qemu_system'} $self->{'qemu_params'}";
+}
+
 sub qemu_start
 {
 	my ($self) = @_;
-	my $cmdline = "qemu-system-$self->{'qemu_system'} $self->{'qemu_params'}";
+	my $cmdline = qemu_cmdline($self);
 
 	msg("Starting qemu with: $cmdline\n");
 
@@ -437,6 +455,7 @@ sub qemu_init
             ',readonly';
     }
 
+    $backend{'interactive'} = \&qemu_cmdline;
 	$backend{'start'} = \&qemu_start;
 	$backend{'stop'} = \&qemu_stop;
 	$backend{'force_stop'} = \&qemu_stop;
@@ -613,7 +632,7 @@ sub new
 	my @backend_params = quotewords(':', 0, $opts);
 	my $backend_type = shift @backend_params;
 
-	msg("Running test with $backend_type parameters '@backend_params'\n");
+	msg("Using $backend_type backend; parameters '@backend_params'\n");
 
 	for (@backends) {
 		return $_->[2]->(@backend_params) if ($_->[0] eq $backend_type);

--- a/backend.pm
+++ b/backend.pm
@@ -370,7 +370,7 @@ sub qemu_stop
 	msg("Failed to stop qemu, killing it!\n");
 
 	kill('TERM', $self->{'pid'});
-	waitpid($self->{'pid'}, 0);
+	return waitpid($self->{'pid'}, 0) < 0 ? -1 : 0
 }
 
 sub print_help

--- a/backend.pm
+++ b/backend.pm
@@ -433,7 +433,8 @@ sub qemu_init
         $backend{'qemu_params'} .= ' -virtfs local' .
             ',path=' . $backend{'qemu_virtfs'} .
             ',mount_tag=host' .
-            ',security_model=mapped-xattr';
+            ',security_model=mapped-xattr' .
+            ',readonly';
     }
 
 	$backend{'start'} = \&qemu_start;

--- a/backend.pm
+++ b/backend.pm
@@ -229,7 +229,7 @@ sub serial_relay_force_stop
 
 	my $port = $self->{'serial_relay_port'};
 
-	msg("Resetting machine backend $self->{'backend_name'} serial relay port $port\n");
+	msg("Resetting machine backend $self->{'name'} serial relay port $port\n");
 
 	open(my $fh, '<', $port);
 	sleep(0.1);

--- a/runltp-ng
+++ b/runltp-ng
@@ -88,7 +88,7 @@ if ($sysinfo || $list) {
 		$sysinfo = utils::collect_sysinfo($backend);
 		utils::print_sysinfo($sysinfo);
 	}
-	utils::list_testgroups($backend) if ($list);
+	utils::list_testgroups($backend, $ltpdir) if ($list);
 	backend::stop($backend);
 	exit(0);
 }

--- a/runltp-ng
+++ b/runltp-ng
@@ -40,6 +40,7 @@ my $interactive;
 my $exclude;
 my $ltpdir = '/opt/ltp';
 my $install;
+my $repouri;
 my $setup;
 my $cmd;
 my $m32;
@@ -54,6 +55,7 @@ GetOptions("backend=s" => \$backend_opts,
            "exclude=s" => \$exclude,
            "ltpdir=s" => \$ltpdir,
            "install=s" => \$install,
+           "repouri=s" => \$repouri,
            "m32" => \$m32,
 	   "setup" => \$setup,
 	   "cmd=s" => \$cmd,
@@ -72,6 +74,7 @@ if ($help) {
 	print("--exclude=regex    : Exclude tests from test group\n\n");
     print("--ltpdir=path      : Directroy where LTP is, or will be, installed (default /opt/ltp)\n\n");
 	print("--install=hash/tag : Checkout LTP from git, compile it and install\n\n");
+    print("--repouri=path     : Location of the LTP git repo\n\n");
 	print("--m32              : Build 32bit binaries on 64bit architecture\n\n");
 	print("--setup            : Attempts to set up the machine (installs packages)\n\n");
 	print("--cmd=cmd          : Execute command\n\n");
@@ -115,7 +118,7 @@ if ($cmd) {
 }
 
 if ($install) {
-	utils::install_ltp($backend, $ltpdir, $install, $m32, $run);
+	utils::install_ltp($backend, $ltpdir, $install, $m32, $run, $repouri);
 }
 
 if (!backend::run_cmd($backend, "! [ -e $ltpdir ]")) {

--- a/runltp-ng
+++ b/runltp-ng
@@ -36,6 +36,7 @@ my $sysinfo;
 my $verbose;
 my $list;
 my $run;
+my $interactive;
 my $exclude;
 my $ltpdir = '/opt/ltp';
 my $install;
@@ -49,6 +50,7 @@ GetOptions("backend=s" => \$backend_opts,
            "sysinfo" => \$sysinfo,
            "list" => \$list,
            "run=s" => \$run,
+           "interactive" => \$interactive,
            "exclude=s" => \$exclude,
            "ltpdir=s" => \$ltpdir,
            "install=s" => \$install,
@@ -66,6 +68,7 @@ if ($help) {
 	print("--list             : List test groups\n\n");
 	print("--verbose          : Enables verbose mode\n\n");
 	print("--run=testgroup    : Execute group of tests\n\n");
+    print("--interactive      : Print command to start interactive session with SUT\n\n");
 	print("--exclude=regex    : Exclude tests from test group\n\n");
     print("--ltpdir=path      : Directroy where LTP is, or will be, installed (default /opt/ltp)\n\n");
 	print("--install=hash/tag : Checkout LTP from git, compile it and install\n\n");
@@ -91,6 +94,11 @@ if ($sysinfo || $list) {
 	utils::list_testgroups($backend, $ltpdir) if ($list);
 	backend::stop($backend);
 	exit(0);
+}
+
+if ($interactive) {
+    backend::interactive($backend);
+    exit(0);
 }
 
 backend::set_logfile($backend, "$logname.raw");

--- a/runltp-ng
+++ b/runltp-ng
@@ -107,7 +107,7 @@ if ($cmd) {
 }
 
 if ($install) {
-	utils::install_ltp($backend, $ltpdir, $install, $m32);
+	utils::install_ltp($backend, $ltpdir, $install, $m32, $run);
 }
 
 if (!backend::run_cmd($backend, "! [ -e $ltpdir ]")) {

--- a/runltp-ng
+++ b/runltp-ng
@@ -37,6 +37,7 @@ my $verbose;
 my $list;
 my $run;
 my $exclude;
+my $ltpdir = '/opt/ltp';
 my $install;
 my $setup;
 my $cmd;
@@ -49,6 +50,7 @@ GetOptions("backend=s" => \$backend_opts,
            "list" => \$list,
            "run=s" => \$run,
            "exclude=s" => \$exclude,
+           "ltpdir=s" => \$ltpdir,
            "install=s" => \$install,
            "m32" => \$m32,
 	   "setup" => \$setup,
@@ -65,6 +67,7 @@ if ($help) {
 	print("--verbose          : Enables verbose mode\n\n");
 	print("--run=testgroup    : Execute group of tests\n\n");
 	print("--exclude=regex    : Exclude tests from test group\n\n");
+    print("--ltpdir=path      : Directroy where LTP is, or will be, installed (default /opt/ltp)\n\n");
 	print("--install=hash/tag : Checkout LTP from git, compile it and install\n\n");
 	print("--m32              : Build 32bit binaries on 64bit architecture\n\n");
 	print("--setup            : Attempts to set up the machine (installs packages)\n\n");
@@ -104,17 +107,19 @@ if ($cmd) {
 }
 
 if ($install) {
-	utils::install_ltp($backend, $install, $m32);
-} else {
-	if (!backend::run_cmd($backend, "! [ -e /opt/ltp ]")) {
-		utils::install_ltp($backend, undef, $m32);
-	}
+	utils::install_ltp($backend, $ltpdir, $install, $m32);
+}
+
+if (!backend::run_cmd($backend, "! [ -e $ltpdir ]")) {
+    backend::stop($backend);
+    print("LTP dir '$ltpdir' doesn't exist\n");
+    exit(0);
 }
 
 if ($run) {
 	my %results;
 	$results{'sysinfo'} = utils::collect_sysinfo($backend);
-	my ($stats, $test_results) = utils::run_ltp($backend, $run, $exclude);
+	my ($stats, $test_results) = utils::run_ltp($backend, $ltpdir, $run, $exclude);
 	$results{'tests'} = {'stats' => $stats, 'results' => $test_results};
 	results::writelog(\%results, "$logname.json");
 	results::writelog_html(\%results, "$logname.html");

--- a/utils.pm
+++ b/utils.pm
@@ -121,9 +121,7 @@ sub install_git_cmds
 	my @cmds;
 
 	push(@cmds, "git clone https://github.com/linux-test-project/ltp.git");
-	push(@cmds, "cd ltp");
-	push(@cmds, "git checkout $revision") if ($revision);
-	push(@cmds, "cd ..");
+	push(@cmds, "git -C ltp checkout $revision") if ($revision);
 
 	return @cmds;
 }

--- a/utils.pm
+++ b/utils.pm
@@ -117,10 +117,10 @@ sub collect_sysinfo
 
 sub install_git_cmds
 {
-	my ($revision) = @_;
+	my ($revision, $uri) = @_;
 	my @cmds;
 
-	push(@cmds, "git clone https://github.com/linux-test-project/ltp.git");
+	push(@cmds, "git clone $uri ltp");
 	push(@cmds, "git -C ltp checkout $revision") if ($revision);
 
 	return @cmds;
@@ -128,12 +128,13 @@ sub install_git_cmds
 
 sub install_zip_cmds
 {
-	my ($revision) = @_;
+	my ($revision, $uri) = @_;
 	my @cmds;
 
 	$revision //= 'HEAD';
+    $uri =~ s/.git$//;
 
-	push(@cmds, "wget http://github.com/linux-test-project/ltp/archive/$revision.zip -O ltp.zip");
+	push(@cmds, "wget $uri/archive/$revision.zip -O ltp.zip");
 	push(@cmds, "unzip ltp.zip");
 	push(@cmds, "mv ltp-* ltp");
 
@@ -142,8 +143,10 @@ sub install_zip_cmds
 
 sub install_ltp
 {
-	my ($self, $ltpdir, $revision, $m32, $runtest) = @_;
+	my ($self, $ltpdir, $revision, $m32, $runtest, $uri) = @_;
 	my $ret;
+
+    $uri //= 'http://github.com/linux-test-project/ltp.git';
 
 	$ret = install_pkg::install_ltp_pkgs($self, $m32);
 	return $ret if ($ret);
@@ -154,9 +157,9 @@ sub install_ltp
 	push(@cmds, 'cd; if [ -e ltp/ ]; then rm -r ltp/; fi');
 
 	if (check_cmd_retry($self, 'git')) {
-		push(@cmds, install_git_cmds($revision));
+		push(@cmds, install_git_cmds($revision, $uri));
 	} else {
-		push(@cmds, install_zip_cmds($revision));
+		push(@cmds, install_zip_cmds($revision, $uri));
 	}
 
 	push(@cmds, 'cd ltp');

--- a/utils.pm
+++ b/utils.pm
@@ -59,13 +59,13 @@ sub print_sysinfo
 
 sub list_testgroups
 {
-	my ($self) = @_;
+	my ($self, $ltpdir) = @_;
 
-	if (backend::run_cmd($self, "[ -e /opt/ltp/ ]")) {
+	if (backend::run_cmd($self, "[ -e $ltpdir ]")) {
 		print("openposix\n");
 	}
 
-	my ($ret, @log) = backend::run_cmd($self, "ls /opt/ltp/runtest/");
+	my ($ret, @log) = backend::run_cmd($self, "ls $ltpdir/runtest/");
 
 	print ("$_\n") for (@log);
 }

--- a/utils.pm
+++ b/utils.pm
@@ -296,16 +296,18 @@ sub setup_ltp_run
 			'export PATH=$LTPROOT/testcases/bin:$PATH',
 			'cd $LTPROOT/testcases/bin',
 		]);
+
+    return $ret;
 }
 
 sub reboot
 {
-	my ($self, $reason) = @_;
+	my ($self, $reason, $ltpdir) = @_;
 
 	print("$reason, attempting to reboot...\n");
 	my $ret = backend::reboot($self);
 	return $ret if ($ret != 0);
-	return -1 if (!setup_ltp_run($self));
+	return -1 if (setup_ltp_run($self, $ltpdir) != 0);
 	return 0;
 }
 
@@ -456,13 +458,13 @@ sub run_ltp
 		}
 
 		if (!defined($ret)) {
-			last if (reboot($self, 'Machine stopped respoding') != 0);
+			last if(reboot($self, 'Machine stopped respoding', $ltpdir) != 0);
 		} elsif ($ret) {
 			my $tainted = check_tainted($self);
-                        my $err_msg = defined($tainted) ?
-                            'Kernel was tained' : 'Machine stopped responding';
+            my $err_msg = defined($tainted) ?
+                'Kernel was tained' : 'Machine stopped responding';
 			if ($tainted != $start_tainted) {
-				last if(reboot($self, $err_msg) != 0);
+				last if(reboot($self, $err_msg, $ltpdir) != 0);
 			}
 		}
 	}


### PR DESCRIPTION
Lets say you already have LTP installed in ~/qa/ltp-build, then you can do:

```
./runltp-ng --verbose --run=cve --ltpdir=/mnt \
            --backend=qemu:image=/var/lib/libvirt/images/opensuse42.3.qcow2:\
	              password=letmein:virtfs=~/qa/ltp-build
```

And it will run the tests from that location inside the VM. I guess you could
also run a single test without installing LTP by doing:

```
./runltp-ng --verbose --cmd=./cve-1337-12345 \
            --backend=qemu:image=/var/lib/libvirt/images/opensuse42.3.qcow2:\
	              password=letmein:virtfs=~/qa/ltp/testcases/cve/
```

This also switches the drive to use virtio as we are testing in a VM.