### PR TITLE
Features for helping to run Syzkaller reproducers

### DIFF
--- a/backend.pm
+++ b/backend.pm
@@ -271,19 +271,21 @@ sub reboot($$)
 	return $ret;
 }
 
-sub qemu_read_file
+sub qemu_read_file($$)
 {
 	my ($self, $path) = @_;
+	my @lines;
 
 	if (run_cmd($self, "cat \"$path\" > /dev/ttyS1")) {
-		die("Failed to write file to ttyS1");
+		msg("Failed to write file to ttyS1");
+		return @lines;
 	}
 
 	if (run_cmd($self, 'echo "runltp-ng-magic-end-of-file-string" > /dev/ttyS1')) {
-		die("Failed to write to ttyS1");
+		msg("Failed to write to ttyS1");
+		return @lines;
 	}
 
-	my @lines;
 	my $fh = $self->{'transport'};
 
 	while (1) {

--- a/backend.pm
+++ b/backend.pm
@@ -227,11 +227,11 @@ sub start
 
 sub stop
 {
-	my ($self) = @_;
+	my ($self, $timeout) = @_;
 
 	close($self->{'raw_logfile'}) if defined($self->{'raw_logfile'});
 
-	$self->{'stop'}->($self) if defined($self->{'stop'});
+	$self->{'stop'}->($self, $timeout) if defined($self->{'stop'});
 }
 
 sub serial_relay_force_stop
@@ -348,7 +348,7 @@ sub qemu_start
 
 sub qemu_stop
 {
-	my ($self) = @_;
+	my ($self, $timeout) = @_;
 
 	close($self->{'transport'}) if defined($self->{'transport'});
 
@@ -357,8 +357,6 @@ sub qemu_stop
 	msg("Stopping qemu pid $self->{'pid'}\n");
 
 	run_string($self, "poweroff");
-
-	my $timeout = 600;
 
 	while ($timeout > 0) {
 		return if waitpid($self->{'pid'}, WNOHANG);

--- a/backend.pm
+++ b/backend.pm
@@ -207,14 +207,14 @@ sub run_cmds
 	return wantarray ? @log : 0;
 }
 
-sub interactive
+sub interactive($)
 {
 	my ($self) = @_;
 
 	if (defined($self->{'interactive'})) {
-		msg('Run: ' . $self->{'interactive'}->($self) . "\n");
+		msg(0, 'Run: ' . $self->{'interactive'}->($self) . "\n");
 	} else {
-		msg("Interactive not implemented for $self->{'name'}\n");
+		msg(0, "Interactive not implemented for $self->{'name'}\n");
 	}
 }
 

--- a/backend.pm
+++ b/backend.pm
@@ -249,10 +249,10 @@ sub serial_relay_force_stop
 
 sub force_stop
 {
-	my ($self) = @_;
+	my ($self, $timeout) = @_;
 
 	if (defined($self->{'force_stop'})) {
-		return $self->{'force_stop'}->($self);
+		return $self->{'force_stop'}->($self, $timeout);
 	} else {
 		print("Backend $self->{'name'} has to be force stopped manually\n");
 		print("Please bring the machine into usable state and then press any key\n");
@@ -261,11 +261,11 @@ sub force_stop
 	return 0;
 }
 
-sub reboot
+sub reboot($$)
 {
-	my ($self) = @_;
+	my ($self, $timeout) = @_;
 
-	my $ret = force_stop($self);
+	my $ret = force_stop($self, $timeout);
 	return $ret if ($ret != 0);
 	$ret = start($self);
 	return $ret;
@@ -354,7 +354,7 @@ sub qemu_start
 	}
 }
 
-sub qemu_stop
+sub qemu_stop($$)
 {
 	my ($self, $timeout) = @_;
 

--- a/install_pkg.pm
+++ b/install_pkg.pm
@@ -70,7 +70,7 @@ sub detect_distro
 
 sub pkg_to_m32
 {
-	my ($self, $distro, $pkg_name) = @_;
+	my ($distro, $pkg_name) = @_;
 
 	if ($distro eq "debian") {
 		#TODO: we need architecture detection for now default to i386

--- a/install_pkg.pm
+++ b/install_pkg.pm
@@ -106,7 +106,7 @@ sub install_pkg
 		return 'apt-get install -y ' . join(' ', @pkgs);
 
 	} elsif ($distro eq 'suse') {
-		return 'zypper --non-interactive in ' . join(' ', @pkgs);
+		return 'zypper --non-interactive --ignore-unknown in ' . join(' ', @pkgs);
 	}
 	return;
 }
@@ -119,6 +119,11 @@ sub update_pkg_db
 	if ($distro eq "debian") {
 		return "apt-get update";
 	}
+
+	if ($distro eq "suse") {
+		return "zypper --non-interactive ref";
+	}
+
 	return;
 }
 

--- a/install_pkg.pm
+++ b/install_pkg.pm
@@ -60,7 +60,7 @@ sub detect_distro
 	if (utils::run_cmd_retry($self, 'grep -q debian /etc/os-release') == 0) {
 		return "debian";
 	}
-	if (utils::run_cmd_retry($self, 'grep -q opensuse /etc/os-release') == 0) {
+	if (utils::run_cmd_retry($self, 'grep -q suse /etc/os-release') == 0) {
 		return "suse";
 	}
 

--- a/runltp-ng
+++ b/runltp-ng
@@ -38,6 +38,7 @@ my $list;
 my $run;
 my $interactive;
 my $exclude;
+my $include = '.*';
 my $ltpdir = '/opt/ltp';
 my $install;
 my $repouri;
@@ -55,6 +56,7 @@ GetOptions(
 	"run=s" => \$run,
 	"interactive" => \$interactive,
 	"exclude=s" => \$exclude,
+	"include=s" => \$include,
 	"ltpdir=s" => \$ltpdir,
 	"install=s" => \$install,
 	"repouri=s" => \$repouri,
@@ -74,7 +76,8 @@ if ($help) {
 	print("--verbose          : Enables verbose mode\n\n");
 	print("--run=testgroup    : Execute group of tests\n\n");
 	print("--interactive      : Print command to start interactive session with SUT\n\n");
-	print("--exclude=regex    : Exclude tests from test group\n\n");
+	print("--include=regex    : Include tests from test group which match regex (default '.*')\n\n");
+	print("--exclude=regex    : Exclude tests from test group which match regex\n\n");
 	print("--ltpdir=path      : Directroy where LTP is, or will be, installed (default /opt/ltp)\n\n");
 	print("--install=hash/tag : Checkout LTP from git, compile it and install\n\n");
 	print("--repouri=path     : Location of the LTP git repo\n\n");
@@ -134,7 +137,9 @@ if (!backend::run_cmd($backend, "! [ -e $ltpdir ]", $timeout)) {
 if ($run) {
 	my %results;
 	$results{'sysinfo'} = utils::collect_sysinfo($backend);
-	my ($stats, $test_results) = utils::run_ltp($backend, $ltpdir, $run, $exclude, $timeout);
+	my ($stats, $test_results) =
+	    utils::run_ltp($backend, $ltpdir, $run, $timeout,
+			   $include, $exclude);
 	$results{'tests'} = {'stats' => $stats, 'results' => $test_results};
 	results::writelog(\%results, "$logname.json");
 	results::writelog_html(\%results, "$logname.html");

--- a/runltp-ng
+++ b/runltp-ng
@@ -119,7 +119,7 @@ if ($interactive) {
 backend::set_logfile($backend, "$logname.raw");
 backend::start($backend);
 
-if ($setup && install_pkg::install_ltp_pkgs($backend, $m32)) {
+if ($setup && install_pkg::install_ltp_pkgs($backend, $m32 || $run =~ "syzkaller")) {
 	stop_exit(0);
 }
 

--- a/runltp-ng
+++ b/runltp-ng
@@ -95,6 +95,12 @@ log::set_verbosity(1) if ($verbose);
 
 my $backend = backend::new($backend_opts);
 
+sub stop_exit($)
+{
+	backend::stop($backend, $timeout);
+	exit(shift);
+}
+
 if ($sysinfo || $list) {
 	backend::start($backend);
 	if ($sysinfo) {
@@ -102,8 +108,7 @@ if ($sysinfo || $list) {
 		utils::print_sysinfo($sysinfo);
 	}
 	utils::list_testgroups($backend, $ltpdir) if ($list);
-	backend::stop($backend, $timeout);
-	exit(0);
+	stop_exit(0);
 }
 
 if ($interactive) {
@@ -114,9 +119,8 @@ if ($interactive) {
 backend::set_logfile($backend, "$logname.raw");
 backend::start($backend);
 
-if ($setup) {
-	install_pkg::install_ltp_pkgs($backend, $m32);
-	exit(0);
+if ($setup && install_pkg::install_ltp_pkgs($backend, $m32)) {
+	stop_exit(0);
 }
 
 if ($cmd) {
@@ -124,14 +128,13 @@ if ($cmd) {
 	print("$_\n") for (@result);
 }
 
-if ($install) {
-	utils::install_ltp($backend, $ltpdir, $install, $m32, $run, $repouri);
+if ($install && utils::install_ltp($backend, $ltpdir, $install, $m32, $run, $repouri)) {
+	stop_exit(0);
 }
 
 if (!backend::run_cmd($backend, "! [ -e $ltpdir ]", $timeout)) {
-	backend::stop($backend, $timeout);
 	print("LTP dir '$ltpdir' doesn't exist\n");
-	exit(0);
+	stop_exit(0);
 }
 
 if ($run) {

--- a/runltp-ng
+++ b/runltp-ng
@@ -44,8 +44,10 @@ my $repouri;
 my $setup;
 my $cmd;
 my $m32;
+my $timeout = 330;
 
-GetOptions("backend=s" => \$backend_opts,
+GetOptions(
+	"backend=s" => \$backend_opts,
 	"help" => \$help,
 	"logname=s" => \$logname,
 	"sysinfo" => \$sysinfo,
@@ -59,8 +61,9 @@ GetOptions("backend=s" => \$backend_opts,
 	"m32" => \$m32,
 	"setup" => \$setup,
 	"cmd=s" => \$cmd,
-	"verbose" => \$verbose)
-	or die("Error in argument parsing!\n");
+	"verbose" => \$verbose,
+	"timeout=i" => \$timeout
+) or die("Error in argument parsing!\n");
 
 if ($help) {
 	print("Options\n-------\n\n");
@@ -78,6 +81,7 @@ if ($help) {
 	print("--m32              : Build 32bit binaries on 64bit architecture\n\n");
 	print("--setup            : Attempts to set up the machine (installs packages)\n\n");
 	print("--cmd=cmd          : Execute command\n\n");
+	print("--timeout=seconds  : The number of seconds to wait for an action to complete (default 300)\n\n");
 	print("Backend help\n------------\n\n");
 	print("--backend=sh|...[:param=val]...\n\n");
 	backend::help();
@@ -95,7 +99,7 @@ if ($sysinfo || $list) {
 		utils::print_sysinfo($sysinfo);
 	}
 	utils::list_testgroups($backend, $ltpdir) if ($list);
-	backend::stop($backend);
+	backend::stop($backend, $timeout);
 	exit(0);
 }
 
@@ -121,8 +125,8 @@ if ($install) {
 	utils::install_ltp($backend, $ltpdir, $install, $m32, $run, $repouri);
 }
 
-if (!backend::run_cmd($backend, "! [ -e $ltpdir ]")) {
-	backend::stop($backend);
+if (!backend::run_cmd($backend, "! [ -e $ltpdir ]", $timeout)) {
+	backend::stop($backend, $timeout);
 	print("LTP dir '$ltpdir' doesn't exist\n");
 	exit(0);
 }
@@ -130,10 +134,10 @@ if (!backend::run_cmd($backend, "! [ -e $ltpdir ]")) {
 if ($run) {
 	my %results;
 	$results{'sysinfo'} = utils::collect_sysinfo($backend);
-	my ($stats, $test_results) = utils::run_ltp($backend, $ltpdir, $run, $exclude);
+	my ($stats, $test_results) = utils::run_ltp($backend, $ltpdir, $run, $exclude, $timeout);
 	$results{'tests'} = {'stats' => $stats, 'results' => $test_results};
 	results::writelog(\%results, "$logname.json");
 	results::writelog_html(\%results, "$logname.html");
 }
 
-backend::stop($backend);
+backend::stop($backend, $timeout);

--- a/utils.pm
+++ b/utils.pm
@@ -394,7 +394,7 @@ sub parse_test
 
 sub run_ltp
 {
-	my ($self, $ltpdir, $runtest, $exclude) = @_;
+	my ($self, $ltpdir, $runtest, $exclude, $timeout) = @_;
 	my @results;
 	my %reshash;
 
@@ -429,7 +429,7 @@ sub run_ltp
 		next if ($exclude && $tid =~ $exclude);
 		print("Executing $tid\n");
 		my $test_start_time = clock_gettime(CLOCK_MONOTONIC);
-		my ($ret, @log) = backend::run_cmd($self, "$c", 600);
+		my ($ret, @log) = backend::run_cmd($self, "$c", $timeout);
 		my $test_end_time = clock_gettime(CLOCK_MONOTONIC);
 
 		my $result = {};

--- a/utils.pm
+++ b/utils.pm
@@ -148,9 +148,6 @@ sub install_ltp
 
 	$uri //= 'http://github.com/linux-test-project/ltp.git';
 
-	$ret = install_pkg::install_ltp_pkgs($self, $m32);
-	return $ret if ($ret);
-
 	my @cmds = ();
 
 	push(@cmds, "if [ -e $ltpdir ]; then rm -rf $ltpdir; fi");

--- a/utils.pm
+++ b/utils.pm
@@ -166,6 +166,8 @@ sub install_ltp
 	push(@cmds, 'make autotools');
 	if (defined($runtest) && $runtest =~ "openposix") {
 		push(@cmds, "./configure --prefix=$ltpdir --with-open-posix-testsuite");
+	} elsif (defined($runtest) && $runtest =~ "syzkaller") {
+		push(@cmds, "./configure --prefix=$ltpdir --with-syzkaller-repros");
 	} else {
 		push(@cmds, "./configure --prefix=$ltpdir");
 	}


### PR DESCRIPTION
Added timeout argument, because we need much shorter timeouts while running the reproducers.

We also need to protect the qcow2 image. We can do this by creating an overlay with qemu-img and reverting it during reboot. We could also create a new overlay after boot using QEMU's migrate to disk and revert to that to skip bootup. However this requires a bit more work to use QEMU's QMP interface and creates other performance issues with loading and saving RAM.

It may also be nice to add an optional second serial port to separate the kernel log and shell.