### PR TITLE
Support virtio-console

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ QEMU
 ----
 
 First you need a VM image which boots without user input and starts a serial
-terminal on ttyS0 (See Grub section below).
+terminal (See Grub section below).
 
 For Debian and SUSE atleast you may automatically install LTP by doing
 something like the following.
@@ -178,21 +178,25 @@ plus git in order to download and compile the LTP.
 
 The qemu backend runs the testcases inside of an virtual machine. The
 testrunner expects that the machine is configured to start a console on a first
-serial port (console=ttyS0 on x86 kernel command line), the path to the virtual
-machine harddisk image as well as root password has to be specified on the
-command line. Older distributions may need getty enabled in /etc/inittab as
-well so that we can log in on the serial console.
+serial port (console=ttyS0 on x86 kernel command line, or console=hvc0 if the
+serial=virtio option is given), the path to the virtual machine harddisk image
+as well as root password has to be specified on the command line. Older
+distributions may need getty enabled in /etc/inittab as well so that we can log
+in on the serial console.
 
 The force reboot is implemented by killing the qemu process and does not
 require any user specific setup.
 
 #### GRUB2 configuration
 
-To enable console on ttyS0 for a VM do:
+To enable console on a tty device for a VM do:
 
 * open /etc/default/grub
-* add "console=ttyS0, console=tty0"  to 'GRUB\_CMDLINE\_LINUX'
+* add "console=$tty\_name, console=tty0"  to 'GRUB\_CMDLINE\_LINUX'
 * run grub-mkconfig -o /boot/grub/grub.cfg
+
+Where `$tty_name` should be `ttyS0`, unless virtio serial type is used (i.e.
+if you set the `serial=virtio` backend option, then use `hvc0`)
 
 ### SSH backend
 

--- a/backend.pm
+++ b/backend.pm
@@ -276,13 +276,13 @@ sub qemu_read_file($$)
 	my ($self, $path) = @_;
 	my @lines;
 
-	if (run_cmd($self, "cat \"$path\" > /dev/ttyS1")) {
-		msg("Failed to write file to ttyS1");
+	if (run_cmd($self, "cat \"$path\" > /dev/$self->{'transport_dev'}")) {
+		msg("Failed to write file to $self->{'transport_dev'}");
 		return @lines;
 	}
 
-	if (run_cmd($self, 'echo "runltp-ng-magic-end-of-file-string" > /dev/ttyS1')) {
-		msg("Failed to write to ttyS1");
+	if (run_cmd($self, "echo 'runltp-ng-magic-end-of-file-string' > /dev/$self->{'transport_dev'}")) {
+		msg("Failed to write to $self->{'transport_dev'}");
 		return @lines;
 	}
 
@@ -444,6 +444,7 @@ my $qemu_params = [
 	['ram', 'qemu_ram', 'Qemu RAM size, defaults to 1.5G'],
 	['smp', 'qemu_smp', 'Qemu CPUs defaults to 2'],
 	['virtfs', 'qemu_virtfs', 'Path to a host folder to mount in the guest (on /mnt)'],
+	['serial', 'qemu_serial', 'Qemu serial port device type, currently only support isa (default) and virtio'],
 	['ro-image', 'qemu_ro_image', 'Path to an image which will be exposed as read only']
 ];
 
@@ -454,17 +455,30 @@ sub qemu_init
 	my $tty_log = "ttyS0-" . getppid();
 	my $ram = "1.5G";
 	my $smp = 2;
+	my $serial = 'isa';
 
 	parse_params(\%backend, "qemu", $qemu_params, @_);
 
 	$ram = $backend{'qemu_ram'} if (defined($backend{'qemu_ram'}));
 	$smp = $backend{'qemu_smp'} if (defined($backend{'qemu_smp'}));
+	$serial = $backend{'qemu_serial'} if (defined($backend{'qemu_serial'}));
 
 	$backend{'transport_fname'} = $transport_fname;
 	$backend{'qemu_params'} = "-enable-kvm -m $ram -smp $smp -display none";
-	$backend{'qemu_params'} .= " -chardev stdio,id=ttyS0,logfile=$tty_log.log -serial chardev:ttyS0";
-	$backend{'qemu_params'} .= " -serial chardev:transport -chardev file,id=transport,path=$transport_fname";
 	$backend{'qemu_system'} = 'x86_64';
+
+	if ($serial eq 'isa') {
+		$backend{'transport_dev'} = 'ttyS1';
+		$backend{'qemu_params'} .= " -chardev stdio,id=tty,logfile=$tty_log.log -serial chardev:tty";
+		$backend{'qemu_params'} .= " -serial chardev:transport -chardev file,id=transport,path=$transport_fname";
+	} elsif ($serial eq 'virtio') {
+		$backend{'transport_dev'} = 'vport1p1';
+		$backend{'qemu_params'} .= " -device virtio-serial";
+		$backend{'qemu_params'} .= " -chardev stdio,id=tty,logfile=$tty_log.log --device virtconsole,chardev=tty";
+		$backend{'qemu_params'} .= " -device virtserialport,chardev=transport -chardev file,id=transport,path=$transport_fname";
+	} else {
+		die("Unupported serial device type $backend{'qemu_serial'}");
+	}
 
 	die('Qemu image not defined') unless defined($backend{'qemu_image'});
 


### PR DESCRIPTION
Added virtio-console support and make serial device type configurable (through the `serial` backend option). The performance of virtio-console should be better than the default isa-serial device, but in my case it is mainly because [isa-serial is simply not usable](https://lore.kernel.org/lkml/nycvar.YEU.7.76.2004231017470.4730@gjva.wvxbf.pm/), and virtio-console is the only work-around.

The default value for the `serial` option is `isa` since that should be what QEMU defaults to (the isa-serial device), but this might not be true on architectures such as s390x, so maybe we should name it to something else?

This is my first Perl-related PR and my Perl skill is still at novice level, so feel free to edit or make suggestions. Thanks for this tool :)