### PR TITLE
Add VirtIO random number generator device to guests

### DIFF
--- a/backend.pm
+++ b/backend.pm
@@ -464,6 +464,7 @@ sub qemu_init
 	$backend{'qemu_params'} = "-enable-kvm -m $ram -smp $smp -display none";
 	$backend{'qemu_params'} .= " -chardev stdio,id=ttyS0,logfile=$tty_log.log -serial chardev:ttyS0";
 	$backend{'qemu_params'} .= " -serial chardev:transport -chardev file,id=transport,path=$transport_fname";
+	$backend{'qemu_params'} .= " -device virtio-rng-pci";
 	$backend{'qemu_system'} = 'x86_64';
 
 	die('Qemu image not defined') unless defined($backend{'qemu_image'});


### PR DESCRIPTION
Sometimes the VM guests does not have enough entropy, and will block inside certain operations until the system deems there is enough randomess (e.g. `zypper in` or `curl https://example.com`).

This can be observed using strace:

    $ strace curl -v 'https://download.opensuse.org'
    execve("/usr/bin/curl", ["curl", "-v", "https://download.opensuse.org/"], 0x7ffd27b087c0 /* 44 vars */) = 0
    ...omitted...
    write(2, "Connected to download.opensuse.o...", 67) = 67
    futex(0x7f646d668f40, FUTEX_WAKE_PRIVATE, 2147483647) = 0
    getpid()                                = 899
    getrandom(0x5555e57e14a0, 16, GRND_NONBLOCK) = -1 EAGAIN (Resource temporarily unavailable)
    getrandom(    <---- blocks here

With the VirtIO random number generator (a.k.a. virtio-rng) the guests will no longer blocks.

The virtio-rng device should be generally well supported, as it is added to QEMU back in 2012 and its driver in the Linux kernel kernel since version 2.6.26. IIRC in cases where the guests does not support the virtio-rng device will simply be ignored, thus not causing any trouble.