### PR TITLE
Return 0 in qemu_stop when VM poweroff successfully

### DIFF
--- a/backend.pm
+++ b/backend.pm
@@ -384,7 +384,7 @@ sub qemu_stop($$)
 	run_string($self, "poweroff");
 
 	while ($timeout > 0) {
-		return if waitpid($self->{'pid'}, WNOHANG);
+		return 0 if waitpid($self->{'pid'}, WNOHANG);
 		sleep(1);
 		$timeout -= 1;
 		#flush($self);


### PR DESCRIPTION
Returning undef works as well, but this will prevent Perl from emitting a warning.