### PR TITLE
Adds openqa_formatter to modify json for the OpenQA LTP parse

### DIFF
--- a/results.pm
+++ b/results.pm
@@ -2,7 +2,7 @@
 #
 # Linux Test Project test runner
 #
-# Copyright (c) 2017-2018 Cyril Hrubis <chrubis@suse.cz>
+# Copyright (c) 2017-2021 Cyril Hrubis <chrubis@suse.cz>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -29,6 +29,10 @@ sub json_print_string
 
 	$str =~ s/\\/\\\\/g;
 	$str =~ s/"/\\"/g;
+	$str =~ s/\r/\\r/g;
+	$str =~ s/\n/\\n/g;
+	$str =~ s/\f/\\f/g;
+	$str =~ s/\t/\\t/g;
 	$str =~ s/[^[:print:]]//g;
 
 	print($fh '"' . $str . '"');
@@ -437,6 +441,44 @@ sub writelog
 	writelog_json($log, $fh);
 
 	close($fh);
+}
+
+sub json_filter
+{
+	my ($filter, $logs) = @_;
+	my $filters = {
+		'openqa' => \&openqa_filter
+	};
+	return $logs unless ($filter);
+	warn "WARN: $filter is not supported. Logs are not going to change" unless $filters->{$filter};
+	return $filters->{$filter}->($logs);
+}
+
+sub openqa_filter
+{
+	my ($log_data) = @_;
+	my $json_data = {
+		'environment' => $log_data->{sysinfo},
+		'stats' => $log_data->{tests}->{stats},
+		'results' => []
+	};
+
+	for my $r (@{$log_data->{tests}->{results}}) {
+		my $result = 'unk';
+		$result = 'pass' if ($r->{passed} || $r->{skipped});
+		$result = 'fail' if ($r->{failed} || $r->{broken} || $r->{warnings});
+		my $t = {
+			'test_fqn' => $r->{tid},
+			'status' => $result,
+			'test' => {
+				'duration' => $r->{runtime},
+				'result' => $result,
+				'log' => join($/, @{$r->{log}})
+			}
+		};
+		push(@{$json_data->{results}}, $t);
+	}
+	return $json_data;
 }
 
 1;

--- a/runltp-ng
+++ b/runltp-ng
@@ -2,7 +2,7 @@
 #
 # Linux Test Project test runner
 #
-# Copyright (c) 2017-2018 Cyril Hrubis <chrubis@suse.cz>
+# Copyright (c) 2017-2021 Cyril Hrubis <chrubis@suse.cz>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,6 +46,7 @@ my $setup;
 my $cmd;
 my $m32;
 my $timeout = 334;
+my $json_filter;
 
 GetOptions(
 	"backend=s" => \$backend_opts,
@@ -64,27 +65,29 @@ GetOptions(
 	"setup" => \$setup,
 	"cmd=s" => \$cmd,
 	"verbose" => \$verbose,
-	"timeout=i" => \$timeout
+	"timeout=i" => \$timeout,
+	"json_filter=s" => \$json_filter
 ) or die("Error in argument parsing!\n");
 
 if ($help) {
 	print("Options\n-------\n\n");
-	print("--help             : Prints this help\n\n");
-	print("--logname=name     : Name for all generated logs\n\n");
-	print("--sysinfo          : Print system information\n\n");
-	print("--list             : List test groups\n\n");
-	print("--verbose          : Enables verbose mode\n\n");
-	print("--run=testgroup    : Execute group of tests\n\n");
-	print("--interactive      : Print command to start interactive session with SUT\n\n");
-	print("--include=regex    : Include tests from test group which match regex (default '.*')\n\n");
-	print("--exclude=regex    : Exclude tests from test group which match regex\n\n");
-	print("--ltpdir=path      : Directroy where LTP is, or will be, installed (default /opt/ltp)\n\n");
-	print("--install=hash/tag : Checkout LTP from git, compile it and install\n\n");
-	print("--repouri=path     : Location of the LTP git repo\n\n");
-	print("--m32              : Build 32bit binaries on 64bit architecture\n\n");
-	print("--setup            : Attempts to set up the machine (installs packages)\n\n");
-	print("--cmd=cmd          : Execute command\n\n");
-	print("--timeout=seconds  : The number of seconds to wait for an action to complete (default 300)\n\n");
+	print("--help               : Prints this help\n\n");
+	print("--logname=name       : Name for all generated logs\n\n");
+	print("--sysinfo            : Print system information\n\n");
+	print("--list               : List test groups\n\n");
+	print("--verbose            : Enables verbose mode\n\n");
+	print("--run=testgroup      : Execute group of tests\n\n");
+	print("--interactive        : Print command to start interactive session with SUT\n\n");
+	print("--include=regex      : Include tests from test group which match regex (default '.*')\n\n");
+	print("--exclude=regex      : Exclude tests from test group which match regex\n\n");
+	print("--ltpdir=path        : Directroy where LTP is, or will be, installed (default /opt/ltp)\n\n");
+	print("--install=hash/tag   : Checkout LTP from git, compile it and install\n\n");
+	print("--repouri=path       : Location of the LTP git repo\n\n");
+	print("--m32                : Build 32bit binaries on 64bit architecture\n\n");
+	print("--setup              : Attempts to set up the machine (installs packages)\n\n");
+	print("--cmd=cmd            : Execute command\n\n");
+	print("--timeout=seconds    : The number of seconds to wait for an action to complete (default 300)\n\n");
+	print("--json_filter=filter : Specify a filter to apply on the json logs\n\n");
 	print("Backend help\n------------\n\n");
 	print("--backend=sh|...[:param=val]...\n\n");
 	backend::help();
@@ -144,7 +147,7 @@ if ($run) {
 	    utils::run_ltp($backend, $ltpdir, $run, $timeout,
 			   $include, $exclude);
 	$results{'tests'} = {'stats' => $stats, 'results' => $test_results};
-	results::writelog(\%results, "$logname.json");
+	results::writelog(results::json_filter($json_filter, \%results), "$logname.json");
 	results::writelog_html(\%results, "$logname.html");
 }
 


### PR DESCRIPTION
We use the LTP parser in OpenQA which it doesnt understand the json
format produced by runltp_ng. `openqa_formatter` will parse the data
to make them suitable for the OpenQA parser.

VR: http://aquarius.suse.cz/tests/5507