### PR TITLE
Fix regression in exclude and include 

### DIFF
--- a/utils.pm
+++ b/utils.pm
@@ -411,8 +411,8 @@ sub run_ltp
 		chomp;
 
 		my ($tid, $c) = parse_test($runtest, $_);
-		next unless (!$include || $include =~ $tid);
-		next if ($exclude && $exclude =~ $tid);
+		next unless (!$include || ($include =~ $tid || $tid =~ $include));
+		next if ($exclude && ($exclude =~ $tid || $tid =~ $exclude));
 
 		print("Executing $tid\n");
 		my $test_start_time = clock_gettime(CLOCK_MONOTONIC);


### PR DESCRIPTION
This patch is follow up for 13ff090
and c0f37f2 which were trying to fix
support for lists in exclude and include
but at the same time broke support for regexs
Current version keep support for lists and
fixing regex string support for exclude and include.