### PR TITLE
install_pkg: Add options to print packages/commands

### DIFF
--- a/install_pkg.pm
+++ b/install_pkg.pm
@@ -73,11 +73,13 @@ sub foo_to_pkg
 	return $pkg_map{"$foo"};
 }
 
+my @distros = qw(alpine debian fedora suse);
+
 sub detect_distro
 {
 	my ($self) = @_;
 
-	for my $distro (qw(alpine debian fedora suse)) {
+	for my $distro (@distros) {
 		if (utils::run_cmd_retry($self, "grep -q $distro /etc/os-release") == 0) {
 			return $distro;
 		}
@@ -106,14 +108,14 @@ sub setup_m32
 	my ($distro) = @_;
 
 	if ($distro eq "debian") {
-		return ("dpkg --add-architecture i386", "apt-get update");
+		return ("dpkg --add-architecture i386");
 	}
 	return;
 }
 
-sub install_pkg
+sub map_pkgs
 {
-	my ($distro, $foos, $m32) = @_;
+	my ($foos, $distro, $m32) = @_;
 
 	$foos = [$foos] unless (ref($foos) eq 'ARRAY');
 
@@ -121,16 +123,20 @@ sub install_pkg
 
 	@pkgs = map { pkg_to_m32($distro, $_) } @pkgs if ($m32);
 
+	return \@pkgs;
+}
+
+sub install_pkg
+{
+	my ($distro, $pkgs) = @_;
+
 	if ($distro eq 'debian') {
-		return 'apt-get install -y ' . join(' ', @pkgs);
-
+		return 'apt-get install -y ' . join(' ', @$pkgs);
 	} elsif ($distro eq 'fedora') {
-		return 'yum install -y ' . join(' ', @pkgs);
-
+		return 'yum install -y ' . join(' ', @$pkgs);
 	} elsif ($distro eq 'suse') {
-		return 'zypper --non-interactive --ignore-unknown in ' . join(' ', @pkgs);
+		return 'zypper --non-interactive --ignore-unknown in ' . join(' ', @$pkgs);
 	}
-	return;
 }
 
 sub update_pkg_db
@@ -152,28 +158,30 @@ sub update_pkg_db
 	return;
 }
 
-sub install_ltp_pkgs
+sub add_build_pkgs
 {
-	my ($self, $m32) = @_;
-	my $distro = detect_distro($self);
-
-	return unless defined($distro);
+	my ($required_pkgs) = @_;
 
 	# Attempt to install required packages
-	my @required_pkgs = ('make', 'autoconf', 'automake', 'pkg-config', 'gcc', 'bc');
+	my @build_pkgs = ('make',
+		'autoconf',
+		'automake',
+		'pkg-config',
+		'gcc');
 
-	# We need at least one
-	push(@required_pkgs, 'git');
-	push(@required_pkgs, 'unzip');
+	push(@$required_pkgs, @build_pkgs);
 
-	# Attempt to install devel libraries
-	my @devel_libs = (
-		'libaio-devel',
-		'libacl-devel',
-		'libattr-devel',
-		'libcap-devel',
-		'libnuma-devel');
-	push(@required_pkgs, @devel_libs);
+	# We need at least one to get the sources
+	push(@$required_pkgs, 'git');
+	push(@$required_pkgs, 'unzip');
+
+	# Kernel devel so that we can build modules
+	push(@$required_pkgs, ('kernel-devel'));
+}
+
+sub add_runtime_pkgs
+{
+	my ($required_pkgs) = @_;
 
 	# We need mkfs.foo at runtime
 	my @mkfs = (
@@ -182,35 +190,153 @@ sub install_ltp_pkgs
 		'e2fsprogs',
 		'btrfsprogs',
 	);
-	push(@required_pkgs, @mkfs);
+	push(@$required_pkgs, @mkfs);
+
+	# Debian does not install bc by default!
+	push(@$required_pkgs, 'bc');
 
 	# FS quota tests needs quota tools
-	push(@required_pkgs, ('quota'));
+	push(@$required_pkgs, ('quota'));
 
 	# NFS tests needs exportfs
-	push(@required_pkgs, ('nfs-utils'));
+	push(@$required_pkgs, ('nfs-utils'));
+}
 
-	# Kernel devel so that we can build modules
-	push(@required_pkgs, ('kernel-devel'));
+sub get_runtime_pkgs
+{
+	my ($pkgs, $distro) = @_;
+	my $run_pkgs = [];
 
-	my @cmds = ();
-	push(@cmds, update_pkg_db($distro));
-	push(@cmds, install_pkg($distro, \@required_pkgs));
+	add_runtime_pkgs($run_pkgs);
+
+	$run_pkgs = map_pkgs($run_pkgs, $distro);
+
+	push(@$pkgs, @$run_pkgs);
+}
+
+sub add_devel_libs
+{
+	my ($required_pkgs) = @_;
+
+	# Attempt to install devel libraries
+	my @devel_libs = (
+		'libaio-devel',
+		'libacl-devel',
+		'libattr-devel',
+		'libcap-devel',
+		'libnuma-devel'
+	);
+
+	push(@$required_pkgs, @devel_libs);
+}
+
+sub get_build_pkgs
+{
+	my ($pkgs, $distro, $m32) = @_;
+	my $foos = [];
+
+	add_build_pkgs($foos);
+	add_devel_libs($foos);
+
+	$foos = map_pkgs($foos, $distro);
+
+	push(@$pkgs, @$foos);
 
 	if ($m32) {
-		push(@cmds, setup_m32($distro));
-		push(@cmds, install_pkg($distro, \@devel_libs, $m32));
-		push(@cmds, install_pkg($distro, 'gcc', $m32));
+		my $pkgs32 = [];
+		add_devel_libs($pkgs32);
+		push(@$pkgs32, 'gcc');
+
+		$pkgs32 = map_pkgs($pkgs32, $distro, $m32);
+
+		push(@$pkgs, @$pkgs32);
 	}
 
+	return $pkgs;
+}
+
+sub get_install_cmds
+{
+	my ($pkgs, $distro, $m32) = @_;
+	my @cmds = ();
+
+	push(@cmds, setup_m32($distro)) if $m32;
+	push(@cmds, update_pkg_db($distro));
+
+	push(@cmds, install_pkg($distro, $pkgs));
+
+	return \@cmds;
+}
+
+sub install_ltp_pkgs
+{
+	my ($self, $m32) = @_;
+	my $distro = detect_distro($self);
+
+	return unless defined($distro);
+	my $pkgs = [];
+
+	get_build_pkgs($pkgs, $distro, $m32);
+	get_runtime_pkgs($pkgs, $distro);
+
+	my $cmds = get_install_cmds($pkgs, $distro, $m32);
+
 	my @results;
-	if (utils::run_cmds_retry($self, \@cmds, results => \@results) != 0) {
+	if (utils::run_cmds_retry($self, $cmds, results => \@results) != 0) {
 		my $last = $results[$#results];
 		printf("Failed command: %s\n  output:\n%s\n",
 			$last->{cmd}, join("\n  ", @{$last->{log}}));
 		return $last->{ret};
 	}
 	return 0;
+}
+
+use Getopt::Long;
+
+if (not caller())
+{
+	my $distro;
+	my $m32;
+	my $build;
+	my $run;
+	my $help;
+	my $cmd;
+
+	GetOptions(
+		"distro=s" => \$distro,
+		"m32" => \$m32,
+		"build" => \$build,
+		"run" => \$run,
+		"cmd" => \$cmd,
+		"help" => \$help,
+	) or die("Error in argument parsing!\n");
+
+	if ($help) {
+		print("Options\n-------\n\n");
+		print("--help   : Print this help\n\n");
+		print("--distro : Distribution name: " . join(' ', @distros) . "\n\n");
+		print("--m32    : Include 32bit build dependencies\n\n");
+		print("--build  : Include build dependencies\n\n");
+		print("--run    : Include runtime dependencies\n\n");
+		print("--cmd    : Print command line instead of package list\n\n");
+		exit 0;
+	}
+
+	die("No distribution selected!\n") unless $distro;
+	die("Unsupported distribution!\n") unless grep(/^$distro$/i, @distros);
+	die("No packages selected!\n") unless $build or $run;
+
+	my $pkgs = [];
+
+	get_build_pkgs($pkgs, $distro, $m32) if $build;
+	get_runtime_pkgs($pkgs, $distro) if $run;
+
+	if ($cmd) {
+		my $cmds = get_install_cmds($pkgs, $distro, $m32);
+		print "$_\n" for (@$cmds);
+	} else {
+		print(join(' ', @$pkgs) . "\n");
+	}
 }
 
 1;


### PR DESCRIPTION
This commit changes the code so that we can print list of packages
and/or commands to install them as well.

There are no changes to the runltp-ng behavior.

Signed-off-by: Cyril Hrubis <chrubis@suse.cz>